### PR TITLE
Use lua in after plugin

### DIFF
--- a/after/plugin/cmp_vsnip.lua
+++ b/after/plugin/cmp_vsnip.lua
@@ -1,0 +1,1 @@
+require('cmp').register_source('vsnip', require('cmp_vsnip').new())

--- a/after/plugin/cmp_vsnip.vim
+++ b/after/plugin/cmp_vsnip.vim
@@ -1,2 +1,0 @@
-lua require'cmp'.register_source('vsnip', require'cmp_vsnip'.new())
-


### PR DESCRIPTION
Use lua in after plugin

This seems to solve an issue I have on the first install using packer. Other cmp plugins didn't have this error and this seems to be the only difference. I imagine the vim calling lua to require cmp happens too late for packer when it runs? Not sure.

```
async.lua:20: Error in coroutine: ...ack/packer/start/packer.nvim/lua/packer/plugin_utils.lua:204: Vim(lua):E5108: Error executing lua [string ":lua"]:1: module 'cmp' not found:
no field package.preload['cmp']
```